### PR TITLE
[GPDA-2344] action.yml is using a deprecated node version. At runtime…

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -75,5 +75,5 @@ inputs:
       Maximum 90 days unless changed from the repository settings page.
 
 runs:
-  using: "node12"
+  using: "node20"
   main: "dist/index.js"


### PR DESCRIPTION
action.yml is using a deprecated node version.  At runtime, I determined that it's using v20.19.4 in the runner and thus updating the version to 20.